### PR TITLE
Fix users/show package.json

### DIFF
--- a/api/users/show/package.json
+++ b/api/users/show/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "app - api",
+    "name": "app-api",
     "version": "0.0.1",
     "description": "",
     "main": "index.js",


### PR DESCRIPTION
The extra spaces in the name were causing npm install to fail. Plus it was inconsistent with other package.json files.